### PR TITLE
Investigated and corrected dimensions

### DIFF
--- a/src/main/scala/com/edouardfouche/generators/DataGenerator.scala
+++ b/src/main/scala/com/edouardfouche/generators/DataGenerator.scala
@@ -33,6 +33,7 @@ trait DataGenerator {
 
     // TODO: This is a duplicate from code in utils package. But somehow did not find how to import it
     def saveDataSet[T](res: Array[Array[T]], path: String): Unit = {
+      val dir = new File(s"${System.getProperty("user.home")}/datagenerator/").mkdirs()
       val file = new File(path)
       val bw = new BufferedWriter(new FileWriter(file))
       bw.write(s"${(1 to res(0).length) mkString ","} \n") // a little header

--- a/src/main/scala/com/edouardfouche/generators/DataGenerator.scala
+++ b/src/main/scala/com/edouardfouche/generators/DataGenerator.scala
@@ -27,13 +27,13 @@ trait DataGenerator {
 
   def generate(n: Int): Array[Array[Double]]
 
-  def saveSample(path: String = s"${System.getProperty("user.home")}/datagenerator/", discretize: Int = 0): Unit = {
+  final def saveSample(path: String = s"${System.getProperty("user.home")}/datagenerator/", discretize: Int = 0): Unit = { // prevent overridding in subclasses so that TestDimensions using IndependentanData are guranteed to be correct. If override is nessesary adjust test.
+    val dir = new File(path).mkdirs()
     val data = if (discretize > 0) this.generate(1000, discretize)
     else this.generate(1000)
 
     // TODO: This is a duplicate from code in utils package. But somehow did not find how to import it
     def saveDataSet[T](res: Array[Array[T]], path: String): Unit = {
-      val dir = new File(s"${System.getProperty("user.home")}/datagenerator/").mkdirs()
       val file = new File(path)
       val bw = new BufferedWriter(new FileWriter(file))
       bw.write(s"${(1 to res(0).length) mkString ","} \n") // a little header

--- a/src/main/scala/com/edouardfouche/index/AdjustedRankIndex.scala
+++ b/src/main/scala/com/edouardfouche/index/AdjustedRankIndex.scala
@@ -29,7 +29,7 @@ import com.edouardfouche.preprocess.Preprocess
 class AdjustedRankIndex(val values: Array[Array[Double]], val parallelize: Int = 0) extends Index  {
   type T = (Int, Float)
 
-  def createIndex(input: Array[Array[Double]]): Array[Array[T]] = {
+   def createIndex(input: Array[Array[Double]]): Array[Array[T]] = {
     Preprocess.mwRank(input, parallelize)
   }
 

--- a/src/main/scala/com/edouardfouche/index/Index.scala
+++ b/src/main/scala/com/edouardfouche/index/Index.scala
@@ -25,7 +25,7 @@ trait Index {
   type T
   val index: Array[Array[T]] = createIndex(values.transpose) // IMPORTANT: The transpose
 
-  def createIndex(data: Array[Array[Double]]): Array[Array[T]]
+  protected def createIndex(data: Array[Array[Double]]): Array[Array[T]]
 
   def apply(n: Int) = index(n)
 

--- a/src/main/scala/com/edouardfouche/preprocess/DataRef.scala
+++ b/src/main/scala/com/edouardfouche/preprocess/DataRef.scala
@@ -45,7 +45,7 @@ case class DataRef(id: String, path: String, header: Int, separator: String, cat
     * note: I put transpose here, because preprocess expected a list of records, while preprocess.openm returns a list of columns
     */
   def openAndPreprocess(test: Stats, dropClass: Boolean = true, max1000: Boolean = false): test.PreprocessedData = {
-    test.preprocess(Preprocess.open(path, header, separator, excludeIndex, dropClass, max1000).transpose)
+    test.preprocess(Preprocess.open(path, header, separator, excludeIndex, dropClass, max1000))
     // In case preprocess does wrong, this block becomes useful
     //try {
     //  test.preprocess(Preprocess.open(path, header, separator, excludeIndex, dropClass, max1000))

--- a/src/main/scala/com/edouardfouche/stats/external/CMI.scala
+++ b/src/main/scala/com/edouardfouche/stats/external/CMI.scala
@@ -33,7 +33,7 @@ case class CMI(calibrate:Boolean = false, var parallelize:Int = 0) extends Exter
   }
 
   def contrast(m: PreprocessedData, dimensions: Set[Int]): Double = {
-    val unz = dimensions.toArray.sorted.map(x => m(x).unzip)
+    val unz = dimensions.toArray.sorted.map(x => m(x).unzip) // apply method on Preprocessed Data calls out the nth Dimension of the index
     val data = unz.map(x => x._2)
     val ranks = unz.map(x => x._1)
     val s = score(data.transpose.map(_.map(_.toDouble)), ranks.transpose) // This is not nice to have to map back to Double but I have no choice for now

--- a/src/main/scala/com/edouardfouche/worksheets/dim_check.sc
+++ b/src/main/scala/com/edouardfouche/worksheets/dim_check.sc
@@ -87,7 +87,9 @@ noIndex(1).size
 
 // Check for Saved Data
 
+
 Independent(dims, 0.0).saveSample() // TODO: If you call this without having a "datagenerator" dir it wont work
+
 
 
 

--- a/src/main/scala/com/edouardfouche/worksheets/dim_check.sc
+++ b/src/main/scala/com/edouardfouche/worksheets/dim_check.sc
@@ -5,7 +5,6 @@ import com.edouardfouche.stats.mcde._
 import com.edouardfouche.index._
 import com.edouardfouche.preprocess._
 
-// TODO: What if new generators?
 
 // Checking Generators
 
@@ -43,7 +42,6 @@ test_dim(all_gens)
 
 
 // Checking External Tests
-// TODO: What if new Tests?
 
 val all_ex_stats = List(CMI(), HICS(), II(), MAC(), MS(), TC(), UDS())
 val all_mcde_stats = List(KS(), MWB(), MWP(), MWPi(), MWPr(), MWPs(), MWPu(), MWZ(), S())
@@ -88,9 +86,22 @@ noIndex(1).size
 
 // Check for Saved Data
 
+/*
 Independent(dims, 0.0).saveSample()
-val data2 = Preprocess.open(getClass.getResource("/data/Independent-2-0.0.csv").getPath, header = 1, separator = ",", excludeIndex = false, dropClass = true)
+val path = s"${System.getProperty("user.home")}/datagenerator/Independent-2-0.0.csv"
+val data = Preprocess.open(path, header = 1, separator = ",", excludeIndex = false, dropClass = true)
+get_dim(data) // row oriented as it should
 
+val dataclass2 = DataRef("Independent-2-0.0", path, 1, ",", "Test")
+val data5 = dataclass2.open()
+get_dim(data5)
+
+val data6 = dataclass2.openAndPreprocess(MWP()).index
+get_dim(data6) // here was the bug --> openAndPreprocess applied an transpose
+
+
+
+val data2 = Preprocess.open(getClass.getResource("/data/Independent-2-0.0.csv").getPath, header = 1, separator = ",", excludeIndex = false, dropClass = true)
 get_dim(data2) // row oriented as should
 
 val dataclass = DataRef("Independent-2-0.0", getClass.getResource("/data/Independent-2-0.0.csv").getPath, 1, ",", "Test")
@@ -98,14 +109,12 @@ val data3 = dataclass.open()
 get_dim(data3) // works as expected -> row oriented
 
 val data4 = dataclass.openAndPreprocess(CMI()).index
-get_dim(data4) // this is incorrect !!! TODO: Fix Bug at openAndPreProcess
-
+get_dim(data4) // this was incorrect (see above) !!!
 get_dim(exRank.index) // To compare, col oriented -> as it should
 
+*/
 
-
-
-
-
-
-
+val path2 = s"${System.getProperty("user.home")}/datagenerator_for_scalatest/"
+val indi = Independent(dims, 0.0)
+indi.saveSample()
+path2 + indi.id + ".csv"

--- a/src/main/scala/com/edouardfouche/worksheets/dim_check.sc
+++ b/src/main/scala/com/edouardfouche/worksheets/dim_check.sc
@@ -1,3 +1,5 @@
+import java.io.File
+
 import com.edouardfouche.generators._
 import com.edouardfouche.stats.Stats
 import com.edouardfouche.stats.external._
@@ -84,9 +86,9 @@ exRank(0).size
 noIndex(0).size
 noIndex(1).size
 
-// Check for Saved Data
+////// Check for Saved Data
 
-/*
+// Check own generated file
 Independent(dims, 0.0).saveSample()
 val path = s"${System.getProperty("user.home")}/datagenerator/Independent-2-0.0.csv"
 val data = Preprocess.open(path, header = 1, separator = ",", excludeIndex = false, dropClass = true)
@@ -100,7 +102,7 @@ val data6 = dataclass2.openAndPreprocess(MWP()).index
 get_dim(data6) // here was the bug --> openAndPreprocess applied an transpose
 
 
-
+// Check in getClass.getResource("/data/Independent-2-0.0.csv").getPath
 val data2 = Preprocess.open(getClass.getResource("/data/Independent-2-0.0.csv").getPath, header = 1, separator = ",", excludeIndex = false, dropClass = true)
 get_dim(data2) // row oriented as should
 
@@ -112,9 +114,24 @@ val data4 = dataclass.openAndPreprocess(CMI()).index
 get_dim(data4) // this was incorrect (see above) !!!
 get_dim(exRank.index) // To compare, col oriented -> as it should
 
-*/
 
-val path2 = s"${System.getProperty("user.home")}/datagenerator_for_scalatest/"
-val indi = Independent(dims, 0.0)
-indi.saveSample()
-path2 + indi.id + ".csv"
+// Check if Data in getClass.getResource("/data/").getPath has correct shape
+
+def getListOfFiles(dir: String):List[File] = {
+  val d = new File(dir)
+  if (d.exists && d.isDirectory) {
+    d.listFiles.filter(_.isFile).toList
+  } else {
+    List[File]()
+  }
+}
+
+val lst_of_f = getListOfFiles(getClass.getResource("/data/").getPath).map(x => x.getAbsolutePath)
+
+{for{
+  f <- lst_of_f
+  data = Preprocess.open(f, header = 1, separator = ",", excludeIndex = false, dropClass = true)
+  if get_dim(data)._1 == 1000
+} yield true}.size == lst_of_f.size
+
+// --> Data is correct

--- a/src/main/scala/com/edouardfouche/worksheets/dim_check.sc
+++ b/src/main/scala/com/edouardfouche/worksheets/dim_check.sc
@@ -3,6 +3,7 @@ import com.edouardfouche.stats.Stats
 import com.edouardfouche.stats.external._
 import com.edouardfouche.stats.mcde._
 import com.edouardfouche.index._
+import com.edouardfouche.preprocess._
 
 // TODO: What if new generators?
 
@@ -87,13 +88,19 @@ noIndex(1).size
 
 // Check for Saved Data
 
+Independent(dims, 0.0).saveSample()
+val data2 = Preprocess.open(getClass.getResource("/data/Independent-2-0.0.csv").getPath, header = 1, separator = ",", excludeIndex = false, dropClass = true)
 
-Independent(dims, 0.0).saveSample() // TODO: If you call this without having a "datagenerator" dir it wont work
+get_dim(data2) // row oriented as should
 
+val dataclass = DataRef("Independent-2-0.0", getClass.getResource("/data/Independent-2-0.0.csv").getPath, 1, ",", "Test")
+val data3 = dataclass.open()
+get_dim(data3) // works as expected -> row oriented
 
+val data4 = dataclass.openAndPreprocess(CMI()).index
+get_dim(data4) // this is incorrect !!! TODO: Fix Bug at openAndPreProcess
 
-
-
+get_dim(exRank.index) // To compare, col oriented -> as it should
 
 
 

--- a/src/main/scala/com/edouardfouche/worksheets/dim_check.sc
+++ b/src/main/scala/com/edouardfouche/worksheets/dim_check.sc
@@ -1,0 +1,102 @@
+import com.edouardfouche.generators._
+import com.edouardfouche.stats.Stats
+import com.edouardfouche.stats.external._
+import com.edouardfouche.stats.mcde._
+import com.edouardfouche.index._
+
+// TODO: What if new generators?
+
+// Checking Generators
+
+val rows = 50
+val dims = 2
+
+val arr = Independent(dims, 0.0).generate(rows)
+val arr2 = Cross(dims, 0.0).generate(rows)
+
+val all_gens = List(Cross(dims, 0.0).generate(rows), Cubic(1,dims, 0.0).generate(rows), DoubleLinear(1,dims, 0.0).generate(rows),
+  Hourglass(dims, 0.0).generate(rows), Hypercube(dims, 0.0).generate(rows), HypercubeGraph(dims, 0.0).generate(rows),
+  HyperSphere(dims, 0.0).generate(rows), Independent(dims, 0.0).generate(rows), Linear(dims, 0.0).generate(rows), LinearPeriodic(1, dims, 0.0).generate(rows),
+  LinearStairs(4, dims, 0.0).generate(rows), LinearThenDummy(dims, 0.0).generate(rows), LinearThenNoise(dims, 0.0).generate(rows),
+  NonCoexistence(dims, 0.0).generate(rows), Parabolic(1, dims, 0.0).generate(rows), RandomSteps(4, dims, 0.0).generate(rows),
+  Sine(1, dims, 0.0).generate(rows), Sqrt(1, dims, 0.0).generate(rows), Star(dims, 0.0).generate(rows), StraightLines(dims, 0.0).generate(rows),
+  Z(dims, 0.0).generate(rows), Zinv(dims, 0.0).generate(rows))
+
+
+def get_dim[T](arr: Array[Array[T]]): (Int, Int) = {
+  (arr.length, arr(0).length)
+}
+
+
+def test_dim (arr_l: List[Array[Array[Double]]], size: Int = 0, tru: Int = 0): Boolean = {
+  if(arr_l == Nil) size == tru
+  else if (get_dim(arr_l.head) == (rows, dims)) test_dim(arr_l.tail, size + 1 , tru + 1)
+  else test_dim(arr_l.tail, size +1, tru)
+}
+
+test_dim(all_gens)
+
+/**
+  * Generated Data is row oriented (row x cols)
+  */
+
+
+// Checking External Tests
+// TODO: What if new Tests?
+
+val all_ex_stats = List(CMI(), HICS(), II(), MAC(), MS(), TC(), UDS())
+val all_mcde_stats = List(KS(), MWB(), MWP(), MWPi(), MWPr(), MWPs(), MWPu(), MWZ(), S())
+
+def which_row_orient(stats: List[Stats]): List[Boolean] = {
+  {for{
+    stat <- stats
+    data = stat.preprocess(arr)
+  } yield get_dim(data.index)}.map(x => x == (rows, dims))
+}
+
+which_row_orient(all_ex_stats)
+which_row_orient(all_mcde_stats)
+
+/**
+  * After preprocess() --> PreprocessedData = all are row oriented
+  * However val index is col oriented --> See Index Class
+  */
+
+// Also check for all indexstructres --> To be sure that they are all implemented the same
+
+val all_indecies = List(new AdjustedRankIndex(arr), new CorrectedRankIndex(arr), new ExternalRankIndex(arr),
+  new NonIndex(arr), new RankIndex(arr))
+
+def which_row_orient_index(ind: List[Index]):List[Boolean] = {
+    {for {
+      index <- ind
+    } yield get_dim(index.index)}.map(x => x == (rows, dims))
+
+}
+
+
+which_row_orient_index(all_indecies).map(x => !x)
+
+// Apply Method calls the index at dim n (see Index)
+val exRank = new ExternalRankIndex(arr)
+val noIndex = new NonIndex(arr)
+
+exRank(0).size
+noIndex(0).size
+noIndex(1).size
+
+// Check for Saved Data
+
+Independent(dims, 0.0).saveSample() // TODO: If you call this without having a "datagenerator" dir it wont work
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/test/scala/TestDimensions.scala
+++ b/src/test/scala/TestDimensions.scala
@@ -100,8 +100,6 @@ class TestDimensions extends FunSuite {
     } assert(get_dim(data)._1 == dims)
   }
 
-
-
   test("Dir Destructor"){
     FileUtils.deleteDirectory(new File(path))
     assert(Files.notExists(Paths.get(path)))

--- a/src/test/scala/TestDimensions.scala
+++ b/src/test/scala/TestDimensions.scala
@@ -1,0 +1,71 @@
+import com.edouardfouche.generators._
+import com.edouardfouche.index._
+import com.edouardfouche.stats.Stats
+import org.scalatest.FunSuite
+import com.edouardfouche.stats.mcde._
+import com.edouardfouche.stats.external._
+
+
+class TestDimensions extends FunSuite {
+
+  val rows = 50
+  val dims = 2
+  val arr = Independent(dims, 0.0).generate(rows)
+
+  // TODO: What if new Tests?
+  val all_ex_stats = List(CMI(), HICS(), II(), MAC(), MS(), TC(), UDS())
+  val all_mcde_stats = List(KS(), MWB(), MWP(), MWPi(), MWPr(), MWPs(), MWPu(), MWZ(), S())
+
+  val all_indecies = List(new AdjustedRankIndex(arr), new CorrectedRankIndex(arr), new ExternalRankIndex(arr),
+    new NonIndex(arr), new RankIndex(arr))
+
+  val all_gens = List(Cross(dims, 0.0).generate(rows), Cubic(1,dims, 0.0).generate(rows), DoubleLinear(1,dims, 0.0).generate(rows),
+    Hourglass(dims, 0.0).generate(rows), Hypercube(dims, 0.0).generate(rows), HypercubeGraph(dims, 0.0).generate(rows),
+    HyperSphere(dims, 0.0).generate(rows), Independent(dims, 0.0).generate(rows), Linear(dims, 0.0).generate(rows), LinearPeriodic(1, dims, 0.0).generate(rows),
+    LinearStairs(4, dims, 0.0).generate(rows), LinearThenDummy(dims, 0.0).generate(rows), LinearThenNoise(dims, 0.0).generate(rows),
+    NonCoexistence(dims, 0.0).generate(rows), Parabolic(1, dims, 0.0).generate(rows), RandomSteps(4, dims, 0.0).generate(rows),
+    Sine(1, dims, 0.0).generate(rows), Sqrt(1, dims, 0.0).generate(rows), Star(dims, 0.0).generate(rows), StraightLines(dims, 0.0).generate(rows),
+    Z(dims, 0.0).generate(rows), Zinv(dims, 0.0).generate(rows))
+
+
+  def get_dim[T](arr: Array[Array[T]]): (Int, Int) = {
+    (arr.length, arr(0).length)
+  }
+
+  def which_row_orient_stats(stats: List[Stats]): List[Boolean] = {
+      {for{
+        stat <- stats
+        data = stat.preprocess(arr)
+      } yield get_dim(data.index)}.map(x => x == (rows, dims))
+  }
+
+  def which_row_orient_index(ind: List[Index]):List[Boolean] = {
+      {for {
+        index <- ind
+      } yield get_dim(index.index)}.map(x => x == (rows, dims))
+
+  }
+
+
+  test("Checking if generated data has the format rows x cols"){
+
+    def test_dim (arr_l: List[Array[Array[Double]]], size: Int = 0, tru: Int = 0): Boolean = {
+      if(arr_l == Nil) size == tru
+      else if (get_dim(arr_l.head) == (rows, dims)) test_dim(arr_l.tail, size + 1 , tru + 1)
+      else test_dim(arr_l.tail, size +1, tru)
+    }
+
+    assert(test_dim(all_gens))
+  }
+
+  test("Checking if val index is col oriented for all Stats"){
+    which_row_orient_stats(all_ex_stats).map(x => assert(!x))
+    which_row_orient_stats(all_mcde_stats).map(x => assert(!x))
+  }
+
+  // To be sure we may be testing twice the same stuff
+
+  test("Checking if val index is col oriented for all Indexstructures"){
+    which_row_orient_index(all_indecies).map(x => assert(!x))
+  }
+}

--- a/src/test/scala/TestDimensions.scala
+++ b/src/test/scala/TestDimensions.scala
@@ -35,8 +35,9 @@ class TestDimensions extends FunSuite {
 
   val path = s"${System.getProperty("user.home")}/datagenerator_for_scalatest/"
   val indi = Independent(dims, 0.0)
-  indi.saveSample(path) // saveSample is final on Base Class
+  indi.saveSample(path) // saveSample is final on Base Class, dir gets destructed after test
   val data = Preprocess.open(path + indi.id + ".csv", header = 1, separator = ",", excludeIndex = false, dropClass = true)
+  val dataclass = DataRef("Independent-2-0.0", path + indi.id + ".csv", 1, ",", "Test")
 
 
 
@@ -59,7 +60,7 @@ class TestDimensions extends FunSuite {
   }
 
 
-  test("Checking if generated data has the format rows x cols"){
+  test("Checking if generated data is row oriented"){
 
     def test_dim (arr_l: List[Array[Array[Double]]], size: Int = 0, tru: Int = 0): Boolean = {
       if(arr_l == Nil) size == tru
@@ -81,18 +82,17 @@ class TestDimensions extends FunSuite {
     which_row_orient_index(all_indecies).map(x => assert(!x))
   }
 
-  test("Checking if saved no of rows by saveSample != dims"){
+  test("Checking if no of rows in saved data by saveSample != dims"){
     assert(get_dim(data)._1 != dims)
   }
 
   test("Checking if saved data using DataGenerator.saveSample loads row oriented using Preprocess.open() and DataRef(...).open()"){
+    val dataclassData = dataclass.open()
     assert(get_dim(data)._2 == dims)
+    assert(get_dim(dataclassData)._2 == dims)
   }
 
-
-
   test("Checking if DataRef(...).openAndPreprocess() loads col oriented data"){
-    val dataclass = DataRef("Independent-2-0.0", path + indi.id + ".csv", 1, ",", "Test")
 
     for{
       stat <- all_ex_stats ::: all_mcde_stats


### PR DESCRIPTION
- `openAndPreprocess` from `DataRef` did a transpose which is incorrect. Fixed. Now data is col oriented (as it should)
- Investigated shape of data from `DataGenerator` classes (row oriented), `index` accessed from `Stats` and from `Index` (col oriented) and saved using `saveSample` from `DataGenerator` as well as loaded using `open` from `Preprocess` and `DataRef`. They are all correct (see dim_check.sc)
- Created class `TestDimensions` to test if data shape is correct for all cases above. 
- `protected createIndex` at class `Index` so that preprocessed data by this class can only be accessed in col oriented format `createIndex` still keeps row orientation, when `val index` is created a `transpose` changes to col orientation
- Tested if data saved at `getClass.getResource("/data/").getPath` is correctly shaped
- `saveSample` at `DataGenerator` has not been creating the dir to save to (exc. was thrown). Fixed. Now dir to save to is created if not present . 